### PR TITLE
Fixed: Pantone -> Pontoon

### DIFF
--- a/media/lua/client/BuildingObjects/ISNewBuildMenu.lua
+++ b/media/lua/client/BuildingObjects/ISNewBuildMenu.lua
@@ -14,9 +14,9 @@ end
 ISBuildMenu.buildBridgeMenu = function(subMenu, player)
 	-- simple wooden floor
     local floorSprite = ISBuildMenu.getWoodenFloorSprites(player);
-	local floorOption = subMenu:addOption(getText("ContextMenu_Wooden_Pantone"), worldobjects, ISBuildMenu.onWoodenFloorUnderWater, square, floorSprite, player);
+	local floorOption = subMenu:addOption(getText("ContextMenu_Wooden_Pontoon"), worldobjects, ISBuildMenu.onWoodenFloorUnderWater, square, floorSprite, player);
 	local tooltip = ISBuildMenu.newCanBuild(4,5,10,1,5,floorOption, player);
-	tooltip:setName(getText("ContextMenu_Wooden_Pantone"));
+	tooltip:setName(getText("ContextMenu_Wooden_Pontoon"));
 	tooltip.description = getText("Tooltip_craft_woodenFloorDesc") .. tooltip.description;
 	tooltip:setTexture(floorSprite.sprite);
 	ISBuildMenu.requireHammer(floorOption)

--- a/media/lua/shared/Translate/EN/ContextMenu_EN.txt
+++ b/media/lua/shared/Translate/EN/ContextMenu_EN.txt
@@ -24,7 +24,7 @@ ContextMenu_EN = {
 	ContextMenu_bind_boat = "Bind boat",
 	ContextMenu_unbind_boat = "Unbind boat",
 	
-	ContextMenu_Wooden_Pantone = "Wooden pantone",
+	ContextMenu_Wooden_Pontoon = "Wooden pontoon",
 	
 	ContextMenu_Open_Cabin = "Unlock cabin",
 	ContextMenu_Open_Cabin_Force = "Unlock cabin<br>(with %1)",

--- a/media/lua/shared/Translate/PL/ContextMenu_PL.txt
+++ b/media/lua/shared/Translate/PL/ContextMenu_PL.txt
@@ -22,7 +22,7 @@ ContextMenu_PL = {
 	ContextMenu_bind_boat = "Przywiaz lodz",
 	ContextMenu_unbind_boat = "Odwiaz lodz",
 
-	ContextMenu_Wooden_Pantone = "Drewniany poklad",
+	ContextMenu_Wooden_Pontoon = "Drewniany poklad",
 
 	ContextMenu_Open_Cabin = "Otworz kabine",
 	ContextMenu_Open_Cabin_Force = "Otworz kabine<br>(bedzie uzyty<br>%1)",

--- a/media/lua/shared/Translate/PTBR/ContextMenu_PTBR.txt
+++ b/media/lua/shared/Translate/PTBR/ContextMenu_PTBR.txt
@@ -22,7 +22,7 @@ ContextMenu_PTBR = {
 	ContextMenu_bind_boat = "Amarrar barco",
 	ContextMenu_unbind_boat = "Desamarrar barco",
 
-	ContextMenu_Wooden_Pantone = "Deck de madeira",
+	ContextMenu_Wooden_Pontoon = "Deck de madeira",
 
 	ContextMenu_Open_Cabin = "Destrancar cabine",
 	ContextMenu_Open_Cabin_Force = "Destrancar cabine<br>(sera usado<br>%1)",

--- a/media/lua/shared/Translate/RU/ContextMenu_RU.txt
+++ b/media/lua/shared/Translate/RU/ContextMenu_RU.txt
@@ -24,7 +24,7 @@ ContextMenu_RU = {
 	ContextMenu_bind_boat = "Привязать лодку",
 	ContextMenu_unbind_boat = "Отвязать лодку",
 	
-	ContextMenu_Wooden_Pantone = "Деревянный понтон",
+	ContextMenu_Wooden_Pontoon = "Деревянный понтон",
 	
 	ContextMenu_Open_Cabin = "Открыть каюту",
 	ContextMenu_Open_Cabin_Force = "Открыть каюту<br>(будет использоваться<br>%1)",


### PR DESCRIPTION
Pantone is a word in English meaning "a system for matching colors, used in specifying printing inks", whereas pontoon means "a flat-bottomed boat or hollow metal cylinder used with others to support a temporary bridge or floating landing stage" which seems more appropriate for the context of the mod. In the other translations, this is "Wooden Deck" which also makes sense in English.